### PR TITLE
Fix session store override and the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ $ go build
 $ ./examples
 ```
 
-Now open up your browser and go to [http://localhost:8088](http://localhost:8088) to see the example.
+Now open up your browser and go to [http://localhost:8088/login/google](http://localhost:8088/login/google) to see the example.
 
 To actually use the different providers, please make sure you set environment variables. Example given in the examples/main.go file
 

--- a/README.md
+++ b/README.md
@@ -99,38 +99,46 @@ To actually use the different providers, please make sure you set environment va
 
 ## Security Notes
 
-By default, goth uses a `Session` from the `gofiber/session` package to store session data.
+By default, goth_fiber uses a `Session` from the `gofiber/session` package to store session data.
 
-As configured, this default store (`session.Session`) will generate cookies with `session.Config`:
+As configured, goth will generate cookies with the following `session.Config`:
 
 ```go
     session.Config{
-        Key:    "dinosaurus",       // default: "sessionid"
-        Lookup: "header",           // default: "cookie"
-        Domain: "google.com",       // default: ""
-        Expires: 30 * time.Minutes, // default: 2 * time.Hour
-        Secure:  true,              // default: false
-    }
+	    Expiration: 24 * time.Hour,
+	    Storage:    memory.New(),
+	    KeyLookup: "cookie:_gothic_session",
+	    CookieDomain: "",
+	    CookiePath: "",
+	    CookieSecure: false,
+	    CookieHTTPOnly: true,
+	    CookieSameSite: "Lax",
+	    KeyGenerator: utils.UUIDv4,
+	}
 ```
 
-To tailor these fields for your application, you can override the `goth_fiber.Session` variable at startup.
+To tailor these fields for your application, you can override the `goth_fiber.SessionStore` variable at startup.
 
 The following snippet shows one way to do this:
 
 ```go
     // optional config
     config := session.Config{
-        Key:    "dinosaurus",       // default: "sessionid"
-        Lookup: "header",           // default: "cookie"
-        Domain: "google.com",       // default: ""
-        Expires: 30 * time.Minutes, // default: 2 * time.Hour
-        Secure:  true,              // default: false
-     }
+	    Expiration:     30 * time.Minutes,
+	    Storage:        sqlite3.New(), // From github.com/gofiber/storage/sqlite3
+	    KeyLookup:      "header:session_id",
+	    CookieDomain:   "google.com",
+	    CookiePath:     "/users",
+	    CookieSecure:   os.Getenv("ENVIRONMENT") == "production",
+	    CookieHTTPOnly: true, // Should always be enabled
+	    CookieSameSite: "Lax",
+	    KeyGenerator:   utils.UUIDv4,
+	}
 
     // create session handler
     sessions := session.New(config)
 
-    goth_fiber.Session = sessions
+    goth_fiber.SessionStore = sessions
 ```
 
 ## Issues

--- a/examples/main.go
+++ b/examples/main.go
@@ -16,17 +16,17 @@ func main() {
 
 	// Optionally, you can override the session store here:
 	// goth_fiber.SessionStore = session.New(session.Config{
-	// 	CookieName:     "some",
-	// 	CookieHTTPOnly: true,
-	// 	Storage: 				sqlite3.New(),
+	// 	KeyLookup:			"cookie:dinosaurus",
+	// 	CookieHTTPOnly:	true,
+	// 	Storage:				sqlite3.New(),
 	// })
 
 	goth.UseProviders(
-		google.New(os.Getenv("OAUTH_KEY"), os.Getenv("OAUTH_SECRET"), "http://127.0.0.1:8088/auth/callback"),
+		google.New(os.Getenv("OAUTH_KEY"), os.Getenv("OAUTH_SECRET"), "http://127.0.0.1:8088/auth/callback/google"),
 	)
 
-	app.Get("/login", goth_fiber.BeginAuthHandler)
-	app.Get("/auth/callback", func(ctx *fiber.Ctx) error {
+	app.Get("/login/:provider", goth_fiber.BeginAuthHandler)
+	app.Get("/auth/callback/:provider", func(ctx *fiber.Ctx) error {
 		user, err := goth_fiber.CompleteUserAuth(ctx)
 		if err != nil {
 			log.Fatal(err)

--- a/examples/main.go
+++ b/examples/main.go
@@ -14,9 +14,17 @@ import (
 func main() {
 	app := fiber.New()
 
+	// Optionally, you can override the session store here:
+	// goth_fiber.SessionStore = session.New(session.Config{
+	// 	CookieName:     "some",
+	// 	CookieHTTPOnly: true,
+	// 	Storage: 				sqlite3.New(),
+	// })
+
 	goth.UseProviders(
 		google.New(os.Getenv("OAUTH_KEY"), os.Getenv("OAUTH_SECRET"), "http://127.0.0.1:8088/auth/callback"),
 	)
+
 	app.Get("/login", goth_fiber.BeginAuthHandler)
 	app.Get("/auth/callback", func(ctx *fiber.Ctx) error {
 		user, err := goth_fiber.CompleteUserAuth(ctx)
@@ -25,7 +33,6 @@ func main() {
 		}
 
 		return ctx.SendString(user.Email)
-
 	})
 	app.Get("/logout", func(ctx *fiber.Ctx) error {
 		if err := goth_fiber.Logout(ctx); err != nil {

--- a/gothic.go
+++ b/gothic.go
@@ -52,7 +52,7 @@ See https://github.com/markbates/goth/examples/main.go to see this in action.
 func BeginAuthHandler(ctx *fiber.Ctx) error {
 	url, err := GetAuthURL(ctx)
 	if err != nil {
-		return ctx.SendStatus(fiber.StatusTemporaryRedirect)
+		return ctx.Status(fiber.StatusBadRequest).SendString(err.Error())
 	}
 
 	return ctx.Redirect(url, fiber.StatusTemporaryRedirect)

--- a/gothic.go
+++ b/gothic.go
@@ -32,7 +32,7 @@ type key int
 func init() {
 	// optional config
 	config := session.Config{
-		CookieName:     gothic.SessionName,
+		KeyLookup: fmt.Sprintf("cookie:%s", gothic.SessionName),
 		CookieHTTPOnly: true,
 	}
 


### PR DESCRIPTION
Originally just wanted to fix https://github.com/Shareed2k/goth_fiber/issues/5 , but on the way found some bugs, so fixed those too:
- Got this warning with the default session config: `[session] CookieName is deprecated, please use KeyLookup`
  - fix: https://github.com/Shareed2k/goth_fiber/commit/ca478b0e36572acdcdee8510609a2f28dfd36a67  `Resolve CookieName is deprecated warning`
- `BeginAuthHandler` sent a redirect on bad requests
  - fix: https://github.com/Shareed2k/goth_fiber/commit/677c7beb8441a4b46d88e1d5654a19e3be5bcdc7 `Respond with 400 when BeginAuth fails.` (BTW This is the same behavior what [gothic does](https://github.com/markbates/goth/blob/master/gothic/gothic.go#L67))
- Some instructions regarding the session store override were incorrect
  - fix:  https://github.com/Shareed2k/goth_fiber/commit/c140710ae395fc2cd934d5835a329beb80b82a43 `Fix invalid instructions in the README`
- The `provider` parameter was missing in the example routes, so `/login` and `/auth/callback` routes were thrown an error about the provider were not specified for the given route
  -  fix: https://github.com/Shareed2k/goth_fiber/commit/78144c27aa9e36f218d3a880e7c39121b77a5731 `Fix example by adding the provider parameter`